### PR TITLE
Support gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Added support for GitLab and other environments that provide tokens in
+  environment variables ([#123](https://github.com/di/id/pull/123))
+
 ## [1.1.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-* Added support for GitLab and other environments that provide tokens in
-  environment variables ([#123](https://github.com/di/id/pull/123))
+### Added
+
+* Added support for GitLab CI/CD ([#123](https://github.com/di/id/pull/123))
 
 ## [1.1.0]
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ For Python API usage, there is a single importable function, `detect_credential`
 This function requires an `audience` parameter, which is used when generating
 the OIDC token. This should be set to the intended audience for the token.
 
+If your environment provides the token in an environment variable, please
+ensure the variable is named `<AUDIENCE>_ID_TOKEN` (where AUDIENCE is the
+uppercased `audience` parameter with all characters except ASCII letters
+and digits replaced with underscores.
+
 ## Supported environments
 
 `id` currently supports ambient credential detection in the following environments:
@@ -69,6 +74,8 @@ the OIDC token. This should be set to the intended audience for the token.
   * [Compute Engine](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)
   * and more
 * [Buildkite](https://buildkite.com/docs/agent/v3/cli-oidc)
+* [GitLab](https://docs.gitlab.com/ee/ci/secrets/id_token_authentication.html) (and
+  other environments where the OIDC token is made available in an environment variable)
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,6 @@ For Python API usage, there is a single importable function, `detect_credential`
 This function requires an `audience` parameter, which is used when generating
 the OIDC token. This should be set to the intended audience for the token.
 
-If your environment provides the token in an environment variable, please
-ensure the variable is named `<AUDIENCE>_ID_TOKEN` (where AUDIENCE is the
-uppercased `audience` parameter with all characters except ASCII letters
-and digits replaced with underscores.
-
 ## Supported environments
 
 `id` currently supports ambient credential detection in the following environments:
@@ -74,8 +69,14 @@ and digits replaced with underscores.
   * [Compute Engine](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)
   * and more
 * [Buildkite](https://buildkite.com/docs/agent/v3/cli-oidc)
-* [GitLab](https://docs.gitlab.com/ee/ci/secrets/id_token_authentication.html) (and
-  other environments where the OIDC token is made available in an environment variable)
+* [GitLab](https://docs.gitlab.com/ee/ci/secrets/id_token_authentication.html) (See _environment variables_ below)
+
+### Tokens in environment variables
+
+GitLab provides OIDC tokens through environment variables. The variable name must be
+`<AUD>_ID_TOKEN`  where `<AUD>` is the uppercased audience argument where all
+characters outside of ASCII letters and digits are replaced with "_". A leading digit
+must also be replaced with a "_".
 
 ## Licensing
 

--- a/id/__init__.py
+++ b/id/__init__.py
@@ -59,16 +59,16 @@ def detect_credential(audience: str) -> Optional[str]:
     """
     from ._internal.oidc.ambient import (
         detect_buildkite,
-        detect_env_var,
         detect_gcp,
         detect_github,
+        detect_gitlab,
     )
 
     detectors: List[Callable[..., Optional[str]]] = [
         detect_github,
         detect_gcp,
         detect_buildkite,
-        detect_env_var,
+        detect_gitlab,
     ]
     for detector in detectors:
         credential = detector(audience)

--- a/id/__init__.py
+++ b/id/__init__.py
@@ -61,12 +61,14 @@ def detect_credential(audience: str) -> Optional[str]:
         detect_buildkite,
         detect_gcp,
         detect_github,
+        detect_env_var,
     )
 
     detectors: List[Callable[..., Optional[str]]] = [
         detect_github,
         detect_gcp,
         detect_buildkite,
+        detect_env_var,
     ]
     for detector in detectors:
         credential = detector(audience)

--- a/id/__init__.py
+++ b/id/__init__.py
@@ -59,9 +59,9 @@ def detect_credential(audience: str) -> Optional[str]:
     """
     from ._internal.oidc.ambient import (
         detect_buildkite,
+        detect_env_var,
         detect_gcp,
         detect_github,
-        detect_env_var,
     )
 
     detectors: List[Callable[..., Optional[str]]] = [

--- a/id/_internal/oidc/ambient.py
+++ b/id/_internal/oidc/ambient.py
@@ -37,6 +37,7 @@ _GCP_GENERATEIDTOKEN_REQUEST_URL = "https://iamcredentials.googleapis.com/v1/pro
 
 _env_var_regex = re.compile(r"[^A-Z0-9_]")
 
+
 class _GitHubTokenPayload(BaseModel):
     """
     A trivial model for GitHub's OIDC token endpoint payload.
@@ -261,6 +262,7 @@ def detect_buildkite(audience: str) -> Optional[str]:
 
     return process.stdout.strip()
 
+
 def detect_env_var(audience: str) -> Optional[str]:
     """
     Detect and return ambient OIDC credential from an environment variable.
@@ -278,7 +280,7 @@ def detect_env_var(audience: str) -> Optional[str]:
     logger.debug("Env var: looking for OIDC credentials")
 
     # construct a reasonable env var name from the audience
-    sanitized_audience = _env_var_regex.sub('_', audience.upper())
+    sanitized_audience = _env_var_regex.sub("_", audience.upper())
     var_name = f"{sanitized_audience}_ID_TOKEN"
     token = os.getenv(var_name)
     if token:

--- a/test/unit/internal/oidc/test_ambient.py
+++ b/test/unit/internal/oidc/test_ambient.py
@@ -649,7 +649,7 @@ def test_buildkite_bad_env(monkeypatch):
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
 
-    assert ambient.detect_buildkite("some-audience") == None
+    assert ambient.detect_buildkite("some-audience") is None
     assert logger.debug.calls == [
         pretend.call("Buildkite: looking for OIDC credentials"),
         pretend.call("Buildkite: environment doesn't look like BuildKite; giving up"),
@@ -662,10 +662,12 @@ def test_env_var_bad_env(monkeypatch):
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
 
-    assert ambient.detect_env_var("some-audience") == None
+    assert ambient.detect_env_var("some-audience") is None
     assert logger.debug.calls == [
         pretend.call("Env var: looking for OIDC credentials"),
-        pretend.call("Env var: No token found in variable SOME_AUDIENCE_ID_TOKEN; giving up"),
+        pretend.call(
+            "Env var: No token found in variable SOME_AUDIENCE_ID_TOKEN; giving up"
+        ),
     ]
 
 

--- a/test/unit/internal/oidc/test_ambient.py
+++ b/test/unit/internal/oidc/test_ambient.py
@@ -654,3 +654,29 @@ def test_buildkite_bad_env(monkeypatch):
         pretend.call("Buildkite: looking for OIDC credentials"),
         pretend.call("Buildkite: environment doesn't look like BuildKite; giving up"),
     ]
+
+
+def test_env_var_bad_env(monkeypatch):
+    monkeypatch.delenv("SOME_AUDIENCE_ID_TOKEN", False)
+
+    logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
+    monkeypatch.setattr(ambient, "logger", logger)
+
+    assert ambient.detect_env_var("some-audience") == None
+    assert logger.debug.calls == [
+        pretend.call("Env var: looking for OIDC credentials"),
+        pretend.call("Env var: No token found in variable SOME_AUDIENCE_ID_TOKEN; giving up"),
+    ]
+
+
+def test_env_var(monkeypatch):
+    monkeypatch.setenv("SOME_AUDIENCE_ID_TOKEN", "fakejwt")
+
+    logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
+    monkeypatch.setattr(ambient, "logger", logger)
+
+    assert ambient.detect_env_var("some-audience") == "fakejwt"
+    assert logger.debug.calls == [
+        pretend.call("Env var: looking for OIDC credentials"),
+        pretend.call("Env var: Found token in variable SOME_AUDIENCE_ID_TOKEN"),
+    ]

--- a/test/unit/internal/oidc/test_ambient.py
+++ b/test/unit/internal/oidc/test_ambient.py
@@ -641,3 +641,16 @@ def test_buildkite(monkeypatch):
             text=True,
         )
     ]
+
+
+def test_buildkite_bad_env(monkeypatch):
+    monkeypatch.delenv("BUILDKITE", False)
+
+    logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
+    monkeypatch.setattr(ambient, "logger", logger)
+
+    assert ambient.detect_buildkite("some-audience") == None
+    assert logger.debug.calls == [
+        pretend.call("Buildkite: looking for OIDC credentials"),
+        pretend.call("Buildkite: environment doesn't look like BuildKite; giving up"),
+    ]


### PR DESCRIPTION
I was looking at GitLab pipelines last night so decided to implement this since it was pretty trivial.

Fixes #121

Test pipeline with sigstore: https://gitlab.com/jku/test-oidc/-/blob/main/.gitlab-ci.yml, 
Log from running that: https://gitlab.com/jku/test-oidc/-/pipelines/1044594956

Notes:
* First version of this PR was a generic `detect_env_var()` but based on feedback this was changed to `detect_gitlab()`
* `detect_gitlab()` is indeed better as it enables error handling (see the example pipeline run)
* The fact that we now have to require the user to do something extra (configure the variable correctly) is annoying but there's not much we can do except maybe provide feedback to GitLab if they ask
* there's an unrelated added test for buildkite
* We don't check if the variable actually contains a token. Now that this is GitLab specific I think this is not critical and matches what other detectors dor. Maybe it makes sense to validate the token content but that sounds like a generic nice-to-have feature, not a GitLab specific thing

