### PR TITLE
Drop Python 3.7, add 3.12 to tests and metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
     strategy:
       matrix:
         conf:
-          - { py: "3.7", os: "ubuntu-latest" }
           - { py: "3.8", os: "ubuntu-latest" }
           - { py: "3.9", os: "ubuntu-latest" }
           - { py: "3.10", os: "ubuntu-latest" }
           - { py: "3.11", os: "ubuntu-latest" }
+          - { py: "3.12", os: "ubuntu-latest" }
           # NOTE: We only test Windows and macOS on the latest Python;
           # these primarily exist to ensure that we don't accidentally
           # introduce Linux-isms into the development tooling.
-          - { py: "3.11", os: "windows-latest" }
-          - { py: "3.11", os: "macos-latest" }
+          - { py: "3.12", os: "windows-latest" }
+          - { py: "3.12", os: "macos-latest" }
     runs-on: ${{ matrix.conf.os }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       # NOTE: We intentionally lint against our minimum supported Python.
       - uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -34,7 +34,7 @@ jobs:
       # since it changes slightly between Python versions.
       - uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ as well as performing common development tasks.
 
 ## Requirements
 
-`id`'s only development environment requirement *should* be Python 3.7
+`id`'s only development environment requirement *should* be Python 3.8
 or newer. Development and testing is actively performed on macOS and Linux,
 but Windows and other supported platforms that are supported by Python
 should also work.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GitHub Actions, GitLab pipelines and Google Cloud.
 
 ## Installation
 
-`id` requires Python 3.7 or newer, and can be installed directly via `pip`:
+`id` requires Python 3.8 or newer, and can be installed directly via `pip`:
 
 ```console
 python -m pip install id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,21 +12,18 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Topic :: Security",
   "Topic :: Security :: Cryptography",
 ]
-dependencies = [
-  "pydantic",
-  "requests",
-]
-requires-python = ">=3.7"
+dependencies = ["pydantic", "requests"]
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://pypi.org/project/id/"
@@ -34,12 +31,7 @@ Issues = "https://github.com/di/id/issues"
 Source = "https://github.com/di/id"
 
 [project.optional-dependencies]
-test = [
-  "pytest",
-  "pytest-cov",
-  "pretend",
-  "coverage[toml]",
-]
+test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
   "bandit",
   "black",
@@ -53,11 +45,7 @@ lint = [
   # Needed for protocol typing in 3.7; remove when our minimum Python is 3.8.
   "typing-extensions; python_version < '3.8'",
 ]
-dev = [
-  "build",
-  "bump >= 1.3.2",
-  "id[test,lint]",
-]
+dev = ["build", "bump >= 1.3.2", "id[test,lint]"]
 
 [tool.isort]
 multi_line_output = 3
@@ -100,4 +88,3 @@ line-length = 100
 # TODO: Enable "UP" here once Pydantic allows us to:
 # See: https://github.com/pydantic/pydantic/issues/4146
 select = ["E", "F", "W"]
-target-version = "py37"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,6 @@ lint = [
   # and let Dependabot periodically perform this update.
   "ruff < 0.1.8",
   "types-requests",
-  # Needed for protocol typing in 3.7; remove when our minimum Python is 3.8.
-  "typing-extensions; python_version < '3.8'",
 ]
 dev = ["build", "bump >= 1.3.2", "id[test,lint]"]
 


### PR DESCRIPTION
This drops 3.7 from the supported Pythons, and adds 3.12 to the test matrix.