### PR TITLE
id: add ambient detector for CircleCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,7 @@ run: $(VENV)/pyvenv.cfg
 .PHONY: lint
 lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		black --check $(ALL_PY_SRCS) && \
-		isort --check $(ALL_PY_SRCS) && \
+		ruff format --check $(ALL_PY_SRCS) && \
 		ruff $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE) && \
 		bandit -c pyproject.toml -r $(PY_MODULE) && \
@@ -74,8 +73,7 @@ lint: $(VENV)/pyvenv.cfg
 reformat: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
 		ruff --fix $(ALL_PY_SRCS) && \
-		black $(ALL_PY_SRCS) && \
-		isort $(ALL_PY_SRCS)
+		ruff format $(ALL_PY_SRCS)
 
 .PHONY: test
 test: $(VENV)/pyvenv.cfg

--- a/id/__init__.py
+++ b/id/__init__.py
@@ -59,6 +59,7 @@ def detect_credential(audience: str) -> Optional[str]:
     """
     from ._internal.oidc.ambient import (
         detect_buildkite,
+        detect_circleci,
         detect_gcp,
         detect_github,
         detect_gitlab,
@@ -69,6 +70,7 @@ def detect_credential(audience: str) -> Optional[str]:
         detect_gcp,
         detect_buildkite,
         detect_gitlab,
+        detect_circleci,
     ]
     for detector in detectors:
         credential = detector(audience)

--- a/id/__main__.py
+++ b/id/__main__.py
@@ -36,9 +36,7 @@ def _parser() -> argparse.ArgumentParser:
         description="a tool for generating OIDC identities",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument(
-        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    parser.add_argument("-V", "--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument(
         "-v",
         "--verbose",

--- a/id/_internal/oidc/ambient.py
+++ b/id/_internal/oidc/ambient.py
@@ -320,8 +320,9 @@ def detect_circleci(audience: str) -> Optional[str]:
     if shutil.which("circleci") is None:
         raise AmbientCredentialError("CircleCI: could not find `circleci` in the environment")
 
+    # See NOTE on `detect_buildkite` for why we silence these warnings.
     payload = json.dumps({"aud": audience})
-    process = subprocess.run(
+    process = subprocess.run(  # nosec B603, B607
         ["circleci", "run", "oidc", "get", "--claims", payload],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ Source = "https://github.com/di/id"
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
   "bandit",
-  "black",
-  "isort",
   "interrogate",
   "mypy",
   # NOTE(ww): ruff is under active development, so we pin conservatively here
@@ -44,11 +42,6 @@ lint = [
   "types-requests",
 ]
 dev = ["build", "bump >= 1.3.2", "id[test,lint]"]
-
-[tool.isort]
-multi_line_output = 3
-known_first_party = "id"
-include_trailing_comma = true
 
 [tool.interrogate]
 # don't enforce documentation coverage for packaging, testing, the virtual
@@ -85,4 +78,4 @@ exclude_dirs = ["./test"]
 line-length = 100
 # TODO: Enable "UP" here once Pydantic allows us to:
 # See: https://github.com/pydantic/pydantic/issues/4146
-select = ["E", "F", "W"]
+select = ["I", "E", "F", "W"]

--- a/test/unit/internal/oidc/test_ambient.py
+++ b/test/unit/internal/oidc/test_ambient.py
@@ -95,9 +95,7 @@ def test_detect_github_request_fails(monkeypatch):
         status_code=999,
         content=b"something",
     )
-    requests = pretend.stub(
-        get=pretend.call_recorder(lambda url, **kw: resp), HTTPError=HTTPError
-    )
+    requests = pretend.stub(get=pretend.call_recorder(lambda url, **kw: resp), HTTPError=HTTPError)
     monkeypatch.setattr(ambient, "requests", requests)
 
     with pytest.raises(
@@ -148,9 +146,7 @@ def test_detect_github_bad_payload(monkeypatch):
     monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "faketoken")
     monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "fakeurl")
 
-    resp = pretend.stub(
-        raise_for_status=lambda: None, json=pretend.call_recorder(lambda: {})
-    )
+    resp = pretend.stub(raise_for_status=lambda: None, json=pretend.call_recorder(lambda: {}))
     requests = pretend.stub(get=pretend.call_recorder(lambda url, **kw: resp))
     monkeypatch.setattr(ambient, "requests", requests)
 
@@ -195,9 +191,7 @@ def test_detect_github(monkeypatch):
 
 
 def test_gcp_impersonation_access_token_request_fail(monkeypatch):
-    monkeypatch.setenv(
-        "GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com"
-    )
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com")
 
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
@@ -207,9 +201,7 @@ def test_gcp_impersonation_access_token_request_fail(monkeypatch):
         status_code=999,
         content=b"something",
     )
-    requests = pretend.stub(
-        get=pretend.call_recorder(lambda url, **kw: resp), HTTPError=HTTPError
-    )
+    requests = pretend.stub(get=pretend.call_recorder(lambda url, **kw: resp), HTTPError=HTTPError)
     monkeypatch.setattr(ambient, "requests", requests)
 
     with pytest.raises(
@@ -226,9 +218,7 @@ def test_gcp_impersonation_access_token_request_fail(monkeypatch):
 
 
 def test_gcp_impersonation_access_token_request_timeout(monkeypatch):
-    monkeypatch.setenv(
-        "GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com"
-    )
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com")
 
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
@@ -255,9 +245,7 @@ def test_gcp_impersonation_access_token_request_timeout(monkeypatch):
 
 
 def test_gcp_impersonation_access_token_missing(monkeypatch):
-    monkeypatch.setenv(
-        "GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com"
-    )
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com")
 
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
@@ -280,9 +268,7 @@ def test_gcp_impersonation_access_token_missing(monkeypatch):
 
 
 def test_gcp_impersonation_identity_token_request_fail(monkeypatch):
-    monkeypatch.setenv(
-        "GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com"
-    )
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com")
 
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
@@ -318,9 +304,7 @@ def test_gcp_impersonation_identity_token_request_fail(monkeypatch):
 
 
 def test_gcp_impersonation_identity_token_request_timeout(monkeypatch):
-    monkeypatch.setenv(
-        "GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com"
-    )
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com")
 
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
@@ -353,9 +337,7 @@ def test_gcp_impersonation_identity_token_request_timeout(monkeypatch):
 
 
 def test_gcp_impersonation_identity_token_missing(monkeypatch):
-    monkeypatch.setenv(
-        "GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com"
-    )
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com")
 
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
@@ -387,9 +369,7 @@ def test_gcp_impersonation_identity_token_missing(monkeypatch):
 
 
 def test_gcp_impersonation_succeeds(monkeypatch):
-    monkeypatch.setenv(
-        "GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com"
-    )
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_NAME", "identity@project.iam.gserviceaccount.com")
 
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
@@ -399,9 +379,7 @@ def test_gcp_impersonation_succeeds(monkeypatch):
     get_resp = pretend.stub(
         raise_for_status=lambda: None, json=lambda: {"access_token": access_token}
     )
-    post_resp = pretend.stub(
-        raise_for_status=lambda: None, json=lambda: {"token": oidc_token}
-    )
+    post_resp = pretend.stub(raise_for_status=lambda: None, json=lambda: {"token": oidc_token})
     requests = pretend.stub(
         get=pretend.call_recorder(lambda url, **kw: get_resp),
         post=pretend.call_recorder(lambda url, **kw: post_resp),
@@ -430,9 +408,7 @@ def test_gcp_bad_env(monkeypatch):
     assert ambient.detect_gcp("some-audience") is None
     assert logger.debug.calls == [
         pretend.call("GCP: looking for OIDC credentials"),
-        pretend.call(
-            "GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation"
-        ),
+        pretend.call("GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation"),
         pretend.call("GCP: environment doesn't have GCP product name file; giving up"),
     ]
 
@@ -451,9 +427,7 @@ def test_gcp_wrong_product(monkeypatch):
 
     assert logger.debug.calls == [
         pretend.call("GCP: looking for OIDC credentials"),
-        pretend.call(
-            "GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation"
-        ),
+        pretend.call("GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation"),
         pretend.call(
             "GCP: product name file exists, but product name is 'Unsupported Product'; giving up"
         ),
@@ -472,9 +446,7 @@ def test_detect_gcp_request_fails(monkeypatch):
         status_code=999,
         content=b"something",
     )
-    requests = pretend.stub(
-        get=pretend.call_recorder(lambda url, **kw: resp), HTTPError=HTTPError
-    )
+    requests = pretend.stub(get=pretend.call_recorder(lambda url, **kw: resp), HTTPError=HTTPError)
     monkeypatch.setattr(ambient, "requests", requests)
 
     with pytest.raises(
@@ -551,9 +523,7 @@ def test_detect_gcp(monkeypatch, product_name):
     ]
     assert logger.debug.calls == [
         pretend.call("GCP: looking for OIDC credentials"),
-        pretend.call(
-            "GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation"
-        ),
+        pretend.call("GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation"),
         pretend.call("GCP: requesting OIDC token"),
         pretend.call("GCP: successfully requested OIDC token"),
     ]
@@ -580,9 +550,7 @@ def test_buildkite_agent_error(monkeypatch):
     monkeypatch.setenv("BUILDKITE", "true")
 
     # Mock out the `which` call to show that we have a `buildkite-agent` in our `PATH`.
-    shutil = pretend.stub(
-        which=pretend.call_recorder(lambda bin: "/usr/bin/buildkite-agent")
-    )
+    shutil = pretend.stub(which=pretend.call_recorder(lambda bin: "/usr/bin/buildkite-agent"))
     monkeypatch.setattr(ambient, "shutil", shutil)
 
     # Mock out `run` call to emulate getting a non-zero return code from the `buildkite-agent`.
@@ -590,9 +558,7 @@ def test_buildkite_agent_error(monkeypatch):
         returncode=-1,
         stdout="mock error message",
     )
-    subprocess = pretend.stub(
-        run=pretend.call_recorder(lambda run_args, **kw: resp), PIPE=None
-    )
+    subprocess = pretend.stub(run=pretend.call_recorder(lambda run_args, **kw: resp), PIPE=None)
     monkeypatch.setattr(ambient, "subprocess", subprocess)
 
     with pytest.raises(
@@ -616,9 +582,7 @@ def test_buildkite(monkeypatch):
     monkeypatch.setenv("BUILDKITE", "true")
 
     # Mock out the `which` call to show that we have a `buildkite-agent` in our `PATH`.
-    shutil = pretend.stub(
-        which=pretend.call_recorder(lambda bin: "/usr/bin/buildkite-agent")
-    )
+    shutil = pretend.stub(which=pretend.call_recorder(lambda bin: "/usr/bin/buildkite-agent"))
     monkeypatch.setattr(ambient, "shutil", shutil)
 
     # Mock out `run` call to emulate getting a successful return code from the `buildkite-agent`.
@@ -626,9 +590,7 @@ def test_buildkite(monkeypatch):
         returncode=0,
         stdout="fakejwt",
     )
-    subprocess = pretend.stub(
-        run=pretend.call_recorder(lambda run_args, **kw: resp), PIPE=None
-    )
+    subprocess = pretend.stub(run=pretend.call_recorder(lambda run_args, **kw: resp), PIPE=None)
     monkeypatch.setattr(ambient, "subprocess", subprocess)
 
     assert ambient.detect_buildkite("some-audience") == "fakejwt"
@@ -698,11 +660,7 @@ def test_gitlab(monkeypatch):
     assert ambient.detect_gitlab("11 other audience") == "fakejwt2"
     assert logger.debug.calls == [
         pretend.call("GitLab: looking for OIDC credentials"),
-        pretend.call(
-            "GitLab: Found token in environment variable SOME_AUDIENCE_ID_TOKEN"
-        ),
+        pretend.call("GitLab: Found token in environment variable SOME_AUDIENCE_ID_TOKEN"),
         pretend.call("GitLab: looking for OIDC credentials"),
-        pretend.call(
-            "GitLab: Found token in environment variable _1_OTHER_AUDIENCE_ID_TOKEN"
-        ),
+        pretend.call("GitLab: Found token in environment variable _1_OTHER_AUDIENCE_ID_TOKEN"),
     ]


### PR DESCRIPTION
This adds ambient detection on CircleCI, based on these docs: https://circleci.com/docs/oidc-tokens-with-custom-claims/

I haven't tested it directly yet -- if we get this repo hooked up to CircleCI, then I can probably add a workflow similar to the GCB one 🙂 