### PR TITLE
prep 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.2.0]
+
 ### Added
 
 * Added support for GitLab CI/CD ([#123](https://github.com/di/id/pull/123))
+* Added support for CircleCI ([#144](https://github.com/di/id/pull/144))
+
+### Changed
+
+* The minimum supported Python version is now 3.8 ([#141](https://github.com/di/id/pull/141))
 
 ## [1.1.0]
 
@@ -29,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Initial split from https://github.com/sigstore/sigstore-python
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/di/id/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/di/id/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/di/id/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/di/id/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/di/id/compare/v1.0.0a2...v1.0.0

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ environment is found but `detect_credential` fails to retrieve a token, it raise
   * and more
 * [Buildkite](https://buildkite.com/docs/agent/v3/cli-oidc)
 * [GitLab](https://docs.gitlab.com/ee/ci/secrets/id_token_authentication.html) (See _environment variables_ below)
+* [CircleCI](https://circleci.com/docs/oidc-tokens-with-custom-claims/)
 
 ### Tokens in environment variables
 

--- a/id/__init__.py
+++ b/id/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import Callable, List, Optional
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 
 class IdentityError(Exception):


### PR DESCRIPTION
This preps the CHANGELOG and version for 1.2.0, and updates the README to list CircleCI per #144.