### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,6 @@ version: 2
 
 updates:
   - package-ecosystem: pip
-    directory: "/install"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 99
-    allow:
-    - dependency-type: direct
-    - dependency-type: indirect
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: pip
     directory: /
     schedule:
       interval: daily

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: publish
         uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11
         with:
-          packages_dir: built-packages/
+          packages-dir: built-packages/
 
   release-github:
     needs: [build, generate-provenance]

--- a/id/__init__.py
+++ b/id/__init__.py
@@ -18,7 +18,7 @@ API for retrieving OIDC tokens.
 
 from __future__ import annotations
 
-from typing import Callable, List, Optional
+from typing import Callable
 
 __version__ = "1.2.1"
 
@@ -49,7 +49,7 @@ class GitHubOidcPermissionCredentialError(AmbientCredentialError):
     pass
 
 
-def detect_credential(audience: str) -> Optional[str]:
+def detect_credential(audience: str) -> str | None:
     """
     Try each ambient credential detector, returning the first one to succeed
     or `None` if all fail.
@@ -65,7 +65,7 @@ def detect_credential(audience: str) -> Optional[str]:
         detect_gitlab,
     )
 
-    detectors: List[Callable[..., Optional[str]]] = [
+    detectors: list[Callable[..., str | None]] = [
         detect_github,
         detect_gcp,
         detect_buildkite,

--- a/id/_internal/oidc/ambient.py
+++ b/id/_internal/oidc/ambient.py
@@ -22,7 +22,6 @@ import os
 import re
 import shutil
 import subprocess  # nosec B404
-from typing import Optional
 
 import requests
 from pydantic import BaseModel, StrictStr
@@ -55,7 +54,7 @@ class _GitHubTokenPayload(BaseModel):
     value: StrictStr
 
 
-def detect_github(audience: str) -> Optional[str]:
+def detect_github(audience: str) -> str | None:
     """
     Detect and return a GitHub Actions ambient OIDC credential.
 
@@ -113,7 +112,7 @@ def detect_github(audience: str) -> Optional[str]:
     return payload.value
 
 
-def detect_gcp(audience: str) -> Optional[str]:
+def detect_gcp(audience: str) -> str | None:
     """
     Detect an return a Google Cloud Platform ambient OIDC credential.
 
@@ -214,7 +213,7 @@ def detect_gcp(audience: str) -> Optional[str]:
         return resp.text
 
 
-def detect_buildkite(audience: str) -> Optional[str]:
+def detect_buildkite(audience: str) -> str | None:
     """
     Detect and return a Buildkite ambient OIDC credential.
 
@@ -253,8 +252,7 @@ def detect_buildkite(audience: str) -> Optional[str]:
     # we can do about this.
     process = subprocess.run(  # nosec B603, B607
         ["buildkite-agent", "oidc", "request-token", "--audience", audience],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
 
@@ -266,7 +264,7 @@ def detect_buildkite(audience: str) -> Optional[str]:
     return process.stdout.strip()
 
 
-def detect_gitlab(audience: str) -> Optional[str]:
+def detect_gitlab(audience: str) -> str | None:
     """
     Detect and return a GitLab CI/CD ambient OIDC credential.
 
@@ -301,7 +299,7 @@ def detect_gitlab(audience: str) -> Optional[str]:
     return token
 
 
-def detect_circleci(audience: str) -> Optional[str]:
+def detect_circleci(audience: str) -> str | None:
     """
     Detect and return a CircleCI ambient OIDC credential.
 
@@ -324,8 +322,7 @@ def detect_circleci(audience: str) -> Optional[str]:
     payload = json.dumps({"aud": audience})
     process = subprocess.run(  # nosec B603, B607
         ["circleci", "run", "oidc", "get", "--claims", payload],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
 

--- a/id/_internal/oidc/ambient.py
+++ b/id/_internal/oidc/ambient.py
@@ -16,6 +16,8 @@
 Ambient OIDC credential detection.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,4 @@ exclude_dirs = ["./test"]
 
 [tool.ruff]
 line-length = 100
-# TODO: Enable "UP" here once Pydantic allows us to:
-# See: https://github.com/pydantic/pydantic/issues/4146
-select = ["I", "E", "F", "W"]
+select = ["I", "E", "F", "W", "UP"]

--- a/test/unit/internal/oidc/test_ambient.py
+++ b/test/unit/internal/oidc/test_ambient.py
@@ -573,8 +573,7 @@ def test_buildkite_agent_error(monkeypatch):
     assert subprocess.run.calls == [
         pretend.call(
             ["buildkite-agent", "oidc", "request-token", "--audience", "some-audience"],
-            stdout=None,
-            stderr=None,
+            capture_output=True,
             text=True,
         )
     ]
@@ -600,8 +599,7 @@ def test_buildkite(monkeypatch):
     assert subprocess.run.calls == [
         pretend.call(
             ["buildkite-agent", "oidc", "request-token", "--audience", "some-audience"],
-            stdout=None,
-            stderr=None,
+            capture_output=True,
             text=True,
         )
     ]
@@ -724,8 +722,7 @@ def test_circleci_circlecli_error(monkeypatch):
     assert subprocess.run.calls == [
         pretend.call(
             ["circleci", "run", "oidc", "get", "--claims", payload],
-            stdout=None,
-            stderr=None,
+            capture_output=True,
             text=True,
         )
     ]
@@ -752,8 +749,7 @@ def test_circleci(monkeypatch):
     assert subprocess.run.calls == [
         pretend.call(
             ["circleci", "run", "oidc", "get", "--claims", payload],
-            stdout=None,
-            stderr=None,
+            capture_output=True,
             text=True,
         )
     ]


### PR DESCRIPTION
Shakeout of a few things:

* Remove a dependabot stanza for `/install` (doesn't exist, was probably copied during the `sigstore-python` breakout)
* Fix PyPI publishing parameter (`packages_dir` is deprecated in favor of `packages-dir`)
* Prefer `T | None` and `container[T]` over `Optional[T]` and `Container[T]`
* Enable `ruff`'s `UP` suite (`pyupdate`) and apply fixes from it