### PR TITLE
dependabot: group all actions bump PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 99
     rebase-strategy: "disabled"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This should slightly decrease the overall volume of Dependabot PRs, but batching their changes together.