### PR TITLE
feat: Add 'pipx run' entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Add `pipx run` entry point ([#217](https://github.com/di/id/pull/217))
+
 ## [1.3.0]
 
 ### Added

--- a/id/__main__.py
+++ b/id/__main__.py
@@ -84,5 +84,9 @@ def main() -> None:
         print(token)
 
 
+def entrypoint() -> None:
+    main()
+
+
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/id/__main__.py
+++ b/id/__main__.py
@@ -84,9 +84,5 @@ def main() -> None:
         print(token)
 
 
-def entrypoint() -> None:
-    main()
-
-
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ lint = [
 dev = ["build", "bump >= 1.3.2", "id[test,lint]"]
 
 [project.entry-points."pipx.run"]
-id = "id.__main__:entrypoint"
+id = "id.__main__:main"
 
 [tool.interrogate]
 # don't enforce documentation coverage for packaging, testing, the virtual

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ lint = [
 ]
 dev = ["build", "bump >= 1.3.2", "id[test,lint]"]
 
+[project.entry-points."pipx.run"]
+id = "id.__main__:entrypoint"
+
 [tool.interrogate]
 # don't enforce documentation coverage for packaging, testing, the virtual
 # environment, or the CLI (which is documented separately).


### PR DESCRIPTION
* Allows for running the equivalent of `python -m id` with `pipx run id`.

Example:

```console
$ docker run --rm -ti python:3.12 /bin/bash
root@c4f607410d2e:/# python -m pip install pipx
root@c4f607410d2e:/# python -m pipx ensurepath
Success! Added /root/.local/bin to the PATH environment variable.

Consider adding shell completions for pipx. Run 'pipx completions' for instructions.

You will need to open a new terminal or re-login for the PATH changes to take effect.

Otherwise pipx is ready to go! ✨ 🌟 ✨
root@c4f607410d2e:/# . ~/.bashrc 
root@c4f607410d2e:/# pipx run --no-cache --spec git+https://github.com/matthewfeickert/id.git@feat/add-pipx-run-entrypoint id --help
⚠️  id is already on your PATH and installed at /usr/bin/id. Downloading and running anyway.
usage: id [-h] [-V] [-v] [-d] audience

a tool for generating OIDC identities

positional arguments:
  audience       the OIDC audience to use

options:
  -h, --help     show this help message and exit
  -V, --version  show program's version number and exit
  -v, --verbose  run with additional debug logging; supply multiple times to increase verbosity (default: 0)
  -d, --decode   decode the OIDC token into JSON (default: False)
root@c4f607410d2e:/#
```