### PR TITLE
pyproject: include test dir in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ Homepage = "https://pypi.org/project/id/"
 Issues = "https://github.com/di/id/issues"
 Source = "https://github.com/di/id"
 
+[tool.flit.sdist]
+include = ["test/"]
+
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [


### PR DESCRIPTION
This includes the `test` dir whenever we build an sdist. Confirmed manually by running `python -m build` and unpacking the produced sdist.

Closes #286.

CC @mgorny