### PR TITLE
release: enable PEP 740 attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     needs: [build, generate-provenance]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # To upload via OIDC.
+      id-token: write # To upload via OIDC + generate attestations.
     steps:
       - name: Download artifacts directories # goes to current working directory
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -73,6 +73,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.10.3
         with:
           packages-dir: built-packages/
+          attestations: true
 
   release-github:
     needs: [build, generate-provenance]
@@ -80,16 +81,9 @@ jobs:
     permissions:
       # Needed to upload release assets.
       contents: write
-      # Needed to sign release assets.
-      id-token: write
     steps:
       - name: Download artifacts directories # goes to current working directory
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-
-      - name: Sign artifacts
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
-        with:
-          inputs: ./built-packages/*.tar.gz ./built-packages/*.whl
 
       - name: Upload artifacts to GitHub
         # Confusingly, this action also supports updating releases, not


### PR DESCRIPTION
This enables attestation generation while uploading, and removes the old gh-action-sigstore step that only produces bundles on the GitHub release.