### PR TITLE
refactor: replace requests with urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+* Drop dependency on `requests` in favor of underlying
+  `urllib3` ([#333](https://github.com/di/id/pull/333))
+
 ## [1.5.0]
 
 ### Changed

--- a/id/_internal/oidc/ambient.py
+++ b/id/_internal/oidc/ambient.py
@@ -97,8 +97,7 @@ def detect_github(audience: str) -> str | None:
 
     if resp.status != 200:
         raise AmbientCredentialError(
-            f"GitHub: OIDC token request failed (code={resp.status}, "
-            f"body={resp.data.decode()!r})"
+            f"GitHub: OIDC token request failed (code={resp.status}, body={resp.data.decode()!r})"
         )
 
     try:
@@ -170,8 +169,7 @@ def detect_gcp(audience: str) -> str | None:
 
         if resp.status != 200:
             raise AmbientCredentialError(
-                f"GCP: OIDC token request failed (code={resp.status}, "
-                f"body={resp.data.decode()!r})"
+                f"GCP: OIDC token request failed (code={resp.status}, body={resp.data.decode()!r})"
             )
 
         oidc_token: str = resp.json().get("token")
@@ -211,8 +209,7 @@ def detect_gcp(audience: str) -> str | None:
 
         if resp.status != 200:
             raise AmbientCredentialError(
-                f"GCP: OIDC token request failed (code={resp.status}, "
-                f"body={resp.data.decode()!r})"
+                f"GCP: OIDC token request failed (code={resp.status}, body={resp.data.decode()!r})"
             )
 
         logger.debug("GCP: successfully requested OIDC token")

--- a/id/_internal/oidc/ambient.py
+++ b/id/_internal/oidc/ambient.py
@@ -138,8 +138,8 @@ def detect_gcp(audience: str) -> str | None:
 
         if resp.status != 200:
             raise AmbientCredentialError(
-                f"GCP: access token request failed (code={resp.status}) "
-                f"body={resp.data.decode()!r}"
+                f"GCP: access token request failed (code={resp.status}, "
+                f"body={resp.data.decode()!r})"
             )
 
         access_token = resp.json().get("access_token")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Security",
   "Topic :: Security :: Cryptography",
 ]
-dependencies = ["urllib3 ~= 2.3"]
+dependencies = ["urllib3 >= 2, < 3"]
 requires-python = ">=3.8"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ lint = [
   # NOTE(ww): ruff is under active development, so we pin conservatively here
   # and let Dependabot periodically perform this update.
   "ruff < 0.8.7",
-  "types-requests",
 ]
 dev = ["build", "bump >= 1.3.2", "id[test,lint]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Security",
   "Topic :: Security :: Cryptography",
 ]
-dependencies = ["requests"]
+dependencies = ["urllib3 ~= 2.3"]
 requires-python = ">=3.8"
 
 [project.urls]
@@ -43,7 +43,6 @@ lint = [
   # NOTE(ww): ruff is under active development, so we pin conservatively here
   # and let Dependabot periodically perform this update.
   "ruff < 0.8.2",
-  "types-requests",
 ]
 dev = ["build", "bump >= 1.3.2", "id[test,lint]"]
 


### PR DESCRIPTION
~~(WIP; haven't rewritten the GCP tests yet.)~~

This simplifies our dependency tree a bit,
since requests is built on urllib3 internally.

It also chips away at a larger plan to replace
requests with urllib3 in sigstore-python, per
https://github.com/sigstore/sigstore-python/issues/1040.